### PR TITLE
Add granular DRA status RBAC permissions for ResourceClaim driver updates

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,3 +61,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/driver
+  verbs:
+  - arbitrary-node:patch
+  - arbitrary-node:update

--- a/internal/controller/resourcemonitor_controller.go
+++ b/internal/controller/resourcemonitor_controller.go
@@ -46,6 +46,7 @@ type ResourceMonitorReconciler struct {
 
 //+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/driver,verbs=arbitrary-node:update;arbitrary-node:patch
 
 //+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceslices,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceslices/status,verbs=get;update;patch


### PR DESCRIPTION
## Summary

This PR updates `dynamic-device-scaler` RBAC to align with the Kubernetes v1.36 DRA granular status authorization changes.

The controller updates `ResourceClaim.status.devices`, so in addition to the existing `resourceclaims/status` permission it also needs `resourceclaims/driver` permissions with the `arbitrary-node` verbs.

## Changes

- add `resourceclaims/driver` permissions to the controller RBAC
- grant:
  - `arbitrary-node:update`
  - `arbitrary-node:patch`
- keep the existing `resourceclaims/status` permissions
- update the kubebuilder RBAC annotation to match the shipped manifest

## Why


Starting in Kubernetes v1.36, DRA components that update `ResourceClaim.status.devices` need additional authorization on the synthetic `resourceclaims/driver` subresource.

This controller runs as a control-plane `Deployment`, so `arbitrary-node:*` is the appropriate permission model.

## Verification

- ran `go test ./...`