### PR TITLE
fix: skip node label for zero max devices

### DIFF
--- a/internal/controller/resourcemonitor_controller.go
+++ b/internal/controller/resourcemonitor_controller.go
@@ -180,7 +180,7 @@ func (r *ResourceMonitorReconciler) handleNodes(ctx context.Context, nodeInfos [
 			return fmt.Errorf("failed to handle devices: %v", err)
 		}
 
-		err = utils.UpdateNodeLabel(ctx, r.Client, r.ClientSet, nodeInfo.Name, composableDRASpec)
+		err = utils.UpdateNodeLabel(ctx, r.Client, r.ClientSet, nodeInfo, composableDRASpec)
 		if err != nil {
 			return fmt.Errorf("failed to update node label: %v", err)
 		}

--- a/internal/utils/patch_utils.go
+++ b/internal/utils/patch_utils.go
@@ -278,7 +278,7 @@ func PatchResourceClaimDeviceConditions(ctx context.Context, kubeClient client.C
 }
 
 // UpdateNodeLabel updates the labels of a node.
-func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet kubernetes.Interface, nodeName string, composableDRASpec types.ComposableDRASpec) error {
+func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet kubernetes.Interface, nodeInfo types.NodeInfo, composableDRASpec types.ComposableDRASpec) error {
 	logger := ctrl.LoggerFrom(ctx)
 	logger.V(1).Info("Start updating Node label")
 
@@ -290,7 +290,7 @@ func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet ku
 	}
 
 	for _, cr := range composabilityRequestList.Items {
-		if cr.Spec.Resource.TargetNode == nodeName {
+		if cr.Spec.Resource.TargetNode == nodeInfo.Name {
 			if cr.Spec.Resource.Size > 0 {
 				if notIn(cr.Spec.Resource.Model, installedDevices) {
 					installedDevices = append(installedDevices, cr.Spec.Resource.Model)
@@ -305,7 +305,7 @@ func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet ku
 	}
 
 	for _, rs := range resourceList.Items {
-		if rs.Spec.TargetNode == nodeName {
+		if rs.Spec.TargetNode == nodeInfo.Name {
 			if rs.Status.State == "Online" {
 				if notIn(rs.Spec.Model, installedDevices) {
 					installedDevices = append(installedDevices, rs.Spec.Model)
@@ -325,6 +325,16 @@ func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet ku
 		}
 	}
 
+	for _, modelConstraint := range nodeInfo.Models {
+		if modelConstraint.MaxDeviceSet && modelConstraint.MaxDevice == 0 {
+			for _, deviceInfo := range composableDRASpec.DeviceInfos {
+				if modelConstraint.DeviceName == deviceInfo.K8sDeviceName {
+					notCoexistID = append(notCoexistID, deviceInfo.Index)
+				}
+			}
+		}
+	}
+
 	for _, deviceInfo := range composableDRASpec.DeviceInfos {
 		if notIn(deviceInfo.Index, notCoexistID) {
 			label := composableDRASpec.LabelPrefix + "/" + deviceInfo.K8sDeviceName
@@ -337,5 +347,5 @@ func UpdateNodeLabel(ctx context.Context, kubeClient client.Client, clientSet ku
 
 	logger.V(1).Info("Start patch Node label", "add labels", addLabels, "delete labels", deleteLabels)
 
-	return patchNodeLabel(clientSet, nodeName, addLabels, deleteLabels)
+	return patchNodeLabel(clientSet, nodeInfo.Name, addLabels, deleteLabels)
 }

--- a/internal/utils/patch_utils_test.go
+++ b/internal/utils/patch_utils_test.go
@@ -41,6 +41,7 @@ func TestUpdateNodeLabel(t *testing.T) {
 		existingResourceList *cdioperator.ComposableResourceList
 		existingNode         *corev1.Node
 		nodeName             string
+		nodeInfo             types.NodeInfo
 		composableDRASpec    types.ComposableDRASpec
 		expectedNodeLabels   map[string]string
 		wantErr              bool
@@ -319,6 +320,58 @@ func TestUpdateNodeLabel(t *testing.T) {
 			nodeName: "test",
 			wantErr:  false,
 		},
+		{
+			name: "do not add label when max device is zero",
+			existingRequestList: &cdioperator.ComposabilityRequestList{
+				Items: []cdioperator.ComposabilityRequest{},
+			},
+			existingResourceList: &cdioperator.ComposableResourceList{
+				Items: []cdioperator.ComposableResource{},
+			},
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"composable.fsastech.com/nvidia-a100-80g": "true",
+					},
+				},
+			},
+			nodeName: "test",
+			nodeInfo: types.NodeInfo{
+				Name: "test",
+				Models: []types.ModelConstraints{
+					{
+						Model:        "A100 80G",
+						DeviceName:   "nvidia-a100-80g",
+						MaxDevice:    0,
+						MaxDeviceSet: true,
+					},
+				},
+			},
+			composableDRASpec: types.ComposableDRASpec{
+				DeviceInfos: []types.DeviceInfo{
+					{
+						Index:            1,
+						CDIModelName:     "A100 40G",
+						DriverName:       "gpu.nvidia.com",
+						K8sDeviceName:    "nvidia-a100-40g",
+						CannotCoexistWith: []int{2},
+					},
+					{
+						Index:            2,
+						CDIModelName:     "A100 80G",
+						DriverName:       "gpu.nvidia.com",
+						K8sDeviceName:    "nvidia-a100-80g",
+						CannotCoexistWith: []int{1},
+					},
+				},
+				LabelPrefix: "composable.fsastech.com",
+			},
+			expectedNodeLabels: map[string]string{
+				"composable.fsastech.com/nvidia-a100-40g": "true",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -349,7 +402,12 @@ func TestUpdateNodeLabel(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clientObjects...).Build()
 
-			err := UpdateNodeLabel(context.Background(), fakeClient, kubeClient, tc.nodeName, tc.composableDRASpec)
+			nodeInfo := tc.nodeInfo
+			if nodeInfo.Name == "" {
+				nodeInfo.Name = tc.nodeName
+			}
+
+			err := UpdateNodeLabel(context.Background(), fakeClient, kubeClient, nodeInfo, tc.composableDRASpec)
 
 			if tc.wantErr {
 				if err == nil {


### PR DESCRIPTION
## Summary

This PR prevents DDS from adding attach-allow node labels for devices whose node `size-max` is `0`.

## Changes

- Pass `NodeInfo` into `UpdateNodeLabel`
- Treat `MaxDeviceSet && MaxDevice == 0` as non-attachable
- Match devices by `DeviceName` and `K8sDeviceName`
- Add unit test coverage for the `size-max=0` case